### PR TITLE
Correct uploaded date detection

### DIFF
--- a/src/videoinfo.js
+++ b/src/videoinfo.js
@@ -41,7 +41,8 @@ var VideoInfo = (function() {
 
 		self.date = Try.all(
 			function() {
-				return new Date(document.getElementById("eow-date").textContent);
+				var dateRegex = /.*([A-Z][a-z]{2} [1-3]?[0-9], 20[0-9]{2}).*/
+				return new Date(document.getElementById("watch-uploader-info").textContent.match(dateRegex)[1]);
 			}
 		);
 


### PR DESCRIPTION
This is an update to logic used to capture the uploaded date.

A layout update removed the date HTML element that was being used.
This patch searches the uploader info for a date matching the regex.

As this searches for text matching English formatting such as "Jun 27, 2014", I am not 100% sure how well it fairs in localisations.
